### PR TITLE
Fix update payment status

### DIFF
--- a/DiBs/Managers/DibsPaymentMethod.cs
+++ b/DiBs/Managers/DibsPaymentMethod.cs
@@ -146,6 +146,7 @@ namespace DiBs.Managers
             if (context.Payment.PaymentStatus == PaymentStatus.Pending)
             {
                 context.Payment.AuthorizedDate = DateTime.UtcNow;
+                context.Payment.Status = PaymentStatus.Authorized.ToString();
 
                 return new PostProcessPaymentResult
                 {


### PR DESCRIPTION
According to changes in the Order module, now, we should change the Status property in addition to PaymentStatus. Otherwise, the payment status changes will not be applied